### PR TITLE
fix: change location to workspace root

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,5 +2,6 @@ FROM gitpod/workspace-full:latest
 
 USER gitpod
 #.NET installed via .gitpod.yml task until the following issue is fixed: https://github.com/gitpod-io/gitpod/issues/5090
-ENV DOTNET_ROOT=/tmp/dotnet
-ENV PATH=$PATH:/tmp/dotnet
+ENV DOTNET_VERSION=6.0
+ENV DOTNET_ROOT=/workspace/.dotnet
+ENV PATH=$PATH:$DOTNET_ROOT

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,7 +5,7 @@ tasks:
   # Mitigation for https://github.com/gitpod-io/gitpod/issues/6460 
   - name: Postinstall .NET 6.0 and dev certificates
     init: |
-      mkdir -p /tmp/dotnet && curl -fsSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0 --install-dir /tmp/dotnet 
+      mkdir -p $DOTNET_ROOT && curl -fsSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel $DOTNET_VERSION --install-dir $DOTNET_ROOT 
       dotnet dev-certs https 
       dotnet restore
 


### PR DESCRIPTION
## Description
This PR is based on the changes proposed in https://github.com/gitpod-io/gitpod/issues/5090.
It changes the location to the workspace root so that the installation only needs to take place once, as currently /tmp is not persistent.

## Related Issue(s)
https://github.com/gitpod-io/gitpod/issues/6460
https://github.com/gitpod-io/gitpod/issues/5090

Fixes #3
Fixes #4 
