### PR TITLE
fix: use netcoreapp6.0 in csproj

### DIFF
--- a/dotnetcore.csproj
+++ b/dotnetcore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Description
running the template out of the box gives the following error:
> $ dotnet run
> It was not possible to find any compatible framework version
> The framework 'Microsoft.NETCore.App', version '5.0.0' (x64) was not found.
>   - The following frameworks were found:
>       6.0.0 at [/workspace/.dotnet/shared/Microsoft.NETCore.App]

dotnetcore.csproj shall use the installed TargetFramework

After the fix:
> $ dotnet run
> Hello World!



