### PR TITLE
Retarget to net6.0

### DIFF
--- a/dotnetcore.csproj
+++ b/dotnetcore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Description
Retarget project to .net6 using correct supported target framework 

See https://docs.microsoft.com/en-us/dotnet/standard/frameworks

netcoreapp5.0 and netcoreapp6.0 I can only guess are legacy remnants of the previous .net core naming convention? as the next version of .net core after 3.1 was simply .net 5 (no core in name).

Supersedes #6

## How to test
dotnet run

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
